### PR TITLE
Use trivial methods and allow callback changing

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ void callback(uint8_t* data, size_t size);
 
 int main()
 {
-	win_pipe::receiver receiver("example_pipe", NULL, callback);
+	win_pipe::receiver receiver("example_pipe", callback);
 	std::cin.get();
 }
 

--- a/README.md
+++ b/README.md
@@ -5,15 +5,7 @@ Uses Windows's named pipes for inter-process communication. Senders send data th
 
 ## Features
 ### Supported
-* Sending data
-* Receiving data asynchronously
-* Reuse of pipes
-    * If a sender is closed, another sender can use the same pipe/receiver
-	* A new pipe name does not have to be used
-	* The above also applies to receivers
 * STL container support (std::unordered_map, etc.)
-	* Default constructor
-	* Move constructor
 * Any-size data transfer (within Windows API physical limits)
 
 ### Unsupported
@@ -25,7 +17,8 @@ Uses Windows's named pipes for inter-process communication. Senders send data th
 	* Subsequent senders have to wait in line until the currently connected sender is disconnected
 	* While waiting, sends are discarded
 * Buffering data until a receiver connects
-	* Data sent with no receiver on the other end is discarded by design
+	* This is by design
+	* Data sent with no receiver is discarded
 
 ## Examples
 A slightly more complex example can be found at [example.cpp](example.cpp).
@@ -67,7 +60,7 @@ void callback(uint8_t* data, size_t size)
 }
 ```
 
-## TODO
+## To Do
 1. Make multiple senders work
 1. Fix any bugs that crop up
 

--- a/example.cpp
+++ b/example.cpp
@@ -1,13 +1,15 @@
 #include "win-pipe.h"
 
+#include <array>
 #include <iostream>
 
 void run_receiver();
-void receiver_callback(uint8_t* data, size_t size);
+void receiver_callback1(uint8_t* data, size_t size);
+void receiver_callback2(uint8_t* data, size_t size);
 void run_sender();
 
 int main(int argc, void** argv)
-{
+{    
     if (argc < 2) {
         std::cout << "Specify sender/receiver." << std::endl;
         return EXIT_FAILURE;
@@ -31,29 +33,44 @@ int main(int argc, void** argv)
 
 void run_receiver()
 {
-    std::cout << "Type exit to quit." << std::endl;
+    std::cout << "Type callback to change behavior. Type exit to quit." << std::endl;
+    
+    int current_callback = 0;
+    win_pipe::callback_t callbacks[2] { receiver_callback1, receiver_callback2 };
 
-    win_pipe::receiver receiver { "win-pipe_example", NULL, receiver_callback };
+    std::unordered_map<int, win_pipe::receiver> map;
+    map[0] = win_pipe::receiver { "win-pipe_example", callbacks[current_callback] };
 
     std::string op;
     while (true) {
         std::getline(std::cin, op);
-        if (op == "exit")
+        if (op == "callback") {
+            current_callback++;
+            map[0].set_callback(callbacks[current_callback % 2]);
+        }
+        else if (op == "exit")
             break;
     }
 }
 
-void receiver_callback(uint8_t* data, size_t size)
+void receiver_callback1(uint8_t* data, size_t size)
 {
     auto* message = reinterpret_cast<const char*>(data);
-    std::cout << message << " : " << size << std::endl;
+    std::cout << message << std::endl;
+}
+
+void receiver_callback2(uint8_t* data, size_t size)
+{
+    auto* message = reinterpret_cast<const char*>(data);
+    std::cout << "Received a message " << size << " bytes long!" << std::endl;
 }
 
 void run_sender()
 {
     std::cout << "Send messages to the receiver! Type exit to quit." << std::endl;
 
-    win_pipe::sender sender { "win-pipe_example" };
+    std::unordered_map<int, win_pipe::sender> map;
+    map[0] = win_pipe::sender { "win-pipe_example" };
 
     std::string message;
     while (true) {
@@ -61,6 +78,6 @@ void run_sender()
         if (message == "exit")
             break;
 
-        sender.send(message.c_str(), (DWORD)message.length() + 1);
+        map[0].send(message.c_str(), (DWORD)message.length() + 1);
     }
 }

--- a/win-pipe.h
+++ b/win-pipe.h
@@ -70,8 +70,6 @@ public:
     /// </summary>
     receiver() = default;
 
-    /// <param name="name">Name of the pipe.</param>
-    /// <param name="callback">Callback for when data is read.</param>
     receiver(std::string_view name, callback_t callback)
     {
         m_param = std::make_unique<thread_param>();
@@ -109,6 +107,9 @@ public:
 
     void set_callback(callback_t callback)
     {
+        if (!m_param)
+            return;
+
         std::lock_guard lock { m_param->callback_mutex };
         m_param->callback = callback;
     }
@@ -185,10 +186,6 @@ public:
 
     sender& operator=(sender&&) noexcept = default;
 
-    /// <param name="buffer">Buffer to send.</param>
-    /// <param name="size">Size of input buffer (amount of data to write).</param>
-    ///
-    /// <returns>bool True = success; false = fail.</returns>
     bool send(const void* buffer, DWORD size)
     {
         if (WriteFile(m_pipe.get(), buffer, size, NULL, NULL) == FALSE) {


### PR DESCRIPTION
* Switch to `std::unique_ptr` so trivial methods (i.e. move constructors) can be used, reducing code length
* Implement deleter for `HANDLE` so that `CloseHandle` can be managed via `std::unique_ptr` instead of manually closing during destructors
* Hide previously global functions inside `win_pipe::details` namespace
* Use `std::mutex` before calling callback to allow thread-safe callback switching
* Update README.md